### PR TITLE
高DPI環境でのステータスバーの分割を改善

### DIFF
--- a/source/fittle/src/fittle.cpp
+++ b/source/fittle/src/fittle.cpp
@@ -1171,10 +1171,12 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp){
 				}
 
 				//ステータスバーの分割変更
+				float dpiScale = static_cast<FLOAT>(GetDeviceCaps(GetDC(0), LOGPIXELSX)) / 96.0f;
+
 				sb_size[3] = LOWORD(lp);
-				sb_size[2] = sb_size[3] - 18;
-				sb_size[1] = sb_size[2] - 120;
-				sb_size[0] = sb_size[1] - 100;
+				sb_size[2] = sb_size[3] - 18 * dpiScale;
+				sb_size[1] = sb_size[2] - 120 * dpiScale;
+				sb_size[0] = sb_size[1] - 90 * dpiScale;
 				SendMessage(m_hStatus, SB_SETPARTS, (WPARAM)3, (LPARAM)(LPINT)sb_size);
 				
 				SendMessage(m_hStatus, WM_SIZE, wp, lp);


### PR DESCRIPTION
高DPI環境でぼやけるのを対処するためにWindowsの互換設定[高DPIスケーリング動作を上書きする]オプションを使用するとステータスバーが欠ける問題を改善します。

master
<img width="350" alt="master" src="https://user-images.githubusercontent.com/20138367/187030279-84544654-bb5a-4e67-9310-937c842ce155.png">
pull request
<img width="350" alt="pr" src="https://user-images.githubusercontent.com/20138367/187030289-5ac6b93c-2689-4f63-91c1-9f4426bdf069.png">

